### PR TITLE
fix : 회원 별 폴더 목록 조회 주소 변경

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
@@ -66,8 +66,9 @@ public class MemberController {
     }
 
     /* 회원 별 폴더 조회 */
-    @GetMapping("/members/folders")
-    public List<FolderResponseDto> getMemberFolderList(@AuthUser Member member){
+    @GetMapping("/members/{nickname}/folders")
+    public List<FolderResponseDto> getMemberFolderList(@PathVariable String nickname){
+        Member member = memberService.findMemberByNickname(nickname);
         if(!memberService.isAdminMember(member)) throw new CustomException(ErrorCode.NON_LOGIN);
         return memberService.findFolderListByMember(member);
     }


### PR DESCRIPTION
## 개발 사항
- 회원 별 폴더 목록 조회 api에서 authorization 값이 아닌 `@PathVariable` 을 통해 member를 조회하고, 해당 member에 대한 폴더 목록을 조회하는 것으로 api 수정,


## 기타 사항
- 현재 포스트맨에 체크 표시가 없는 api들은 스크랩 관련 조회 api 들이기 때문에 하은님께서 개발해주시면 될 것 같습니다!
- 개발 완료된 api는 포스트맨에서 체크표시 해주시면 감사하겠습니다 :)