### PR TITLE
feat : 본인 제외 회원 목록 조회 기능 추가

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/follow/repository/FollowRepository.java
+++ b/src/main/java/efub/toy2/papers/domain/follow/repository/FollowRepository.java
@@ -12,4 +12,5 @@ public interface FollowRepository extends JpaRepository<Follow,Long> {
     Optional<Follow> findByFollowerAndFollowing(Member follower , Member following);
     List<Follow> findAllByFollower(Member member);
     List<Follow> findAllByFollowing(Member member);
+    List<Follow> findAllByFollowerIsNot(Member member);
 }

--- a/src/main/java/efub/toy2/papers/domain/follow/service/FollowService.java
+++ b/src/main/java/efub/toy2/papers/domain/follow/service/FollowService.java
@@ -74,12 +74,11 @@ public class FollowService {
     }
 
 
-    /* 팔로워와팔로잉으로 팔로우 조회 */
+    /* 팔로워와 팔로잉으로 팔로우 조회 */
     public Follow findFollowByFollowerAndFollowing(Member follower, Member following){
         return followRepository.findByFollowerAndFollowing(follower,following)
                 .orElseThrow(()->new CustomException(ErrorCode.NO_FOLLOW_EXIST));
     }
-
 
     /* 팔로워로 팔로우 조회 */
     public List<Follow> findFollowListByFollower(Member member){
@@ -91,4 +90,9 @@ public class FollowService {
         return followRepository.findAllByFollowing(member);
     }
 
+
+    /* 팔로우하고 있지 않은 멤버 조회 조회 */
+    public List<Follow> findFollowListByNotFollower(Member member){
+        return followRepository.findAllByFollowerIsNot(member);
+    }
 }

--- a/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
@@ -7,6 +7,7 @@ import efub.toy2.papers.domain.member.dto.request.LoginRequestDto;
 import efub.toy2.papers.domain.member.dto.request.NicknameRequestDto;
 import efub.toy2.papers.domain.member.dto.response.LoginResponseDto;
 import efub.toy2.papers.domain.member.dto.response.MemberInfoDto;
+import efub.toy2.papers.domain.member.dto.response.MemberSearchResponseDto;
 import efub.toy2.papers.domain.member.dto.response.ReissueResponseDto;
 import efub.toy2.papers.domain.member.service.AuthService;
 import efub.toy2.papers.domain.member.service.MemberService;
@@ -72,6 +73,14 @@ public class MemberController {
         if(!memberService.isAdminMember(member)) throw new CustomException(ErrorCode.NON_LOGIN);
         return memberService.findFolderListByMember(member);
     }
+
+    /* 랜덤 회원 목록 리스트 조회 : 우선 팔로우하지 않은 회원 목록 조회하기로... 이후 찾아보고 수정. */
+    @GetMapping("/members/random-list")
+    public List<MemberSearchResponseDto> getRandomMemberList(@AuthUser Member member){
+        return memberService.findRandomMemberList(member);
+
+    }
+
 
 
 

--- a/src/main/java/efub/toy2/papers/domain/member/dto/response/MemberSearchResponseDto.java
+++ b/src/main/java/efub/toy2/papers/domain/member/dto/response/MemberSearchResponseDto.java
@@ -1,0 +1,20 @@
+package efub.toy2.papers.domain.member.dto.response;
+
+import efub.toy2.papers.domain.member.domain.Member;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberSearchResponseDto {
+    public String nickname;
+    public String introduce;
+    public String profileImgURL;
+
+    @Builder
+    public MemberSearchResponseDto(Member member){
+        this.nickname = member.getNickname();
+        this.introduce = member.getIntroduce();
+        this.profileImgURL = member.getProfileImgUrl();
+
+    }
+}

--- a/src/main/java/efub/toy2/papers/domain/member/repository/MemberRepository.java
+++ b/src/main/java/efub/toy2/papers/domain/member/repository/MemberRepository.java
@@ -2,7 +2,9 @@ package efub.toy2.papers.domain.member.repository;
 
 import efub.toy2.papers.domain.member.domain.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
+import java.util.List;
 import java.util.Optional;
 
 
@@ -11,9 +13,9 @@ public interface MemberRepository extends JpaRepository<Member , Long> {
 
    Boolean existsMemberByEmail(String email);
 
-    Boolean existsMemberByNickname(String nickname);
+   Boolean existsMemberByNickname(String nickname);
 
+   Optional<Member> findByNickname(String nickname);
 
-
-    Optional<Member> findByNickname(String nickname);
+   List<Member> findAllByMemberIdIsNot(Long memberId);
 }

--- a/src/main/java/efub/toy2/papers/domain/member/service/MemberService.java
+++ b/src/main/java/efub/toy2/papers/domain/member/service/MemberService.java
@@ -4,10 +4,13 @@ import efub.toy2.papers.domain.folder.domain.Folder;
 import efub.toy2.papers.domain.folder.dto.FolderResponseDto;
 import efub.toy2.papers.domain.folder.repository.FolderRepository;
 import efub.toy2.papers.domain.folder.service.FolderService;
+import efub.toy2.papers.domain.follow.domain.Follow;
+import efub.toy2.papers.domain.follow.service.FollowService;
 import efub.toy2.papers.domain.member.domain.Member;
 import efub.toy2.papers.domain.member.domain.Role;
 import efub.toy2.papers.domain.member.dto.ProfileRequestDto;
 import efub.toy2.papers.domain.member.dto.response.MemberInfoDto;
+import efub.toy2.papers.domain.member.dto.response.MemberSearchResponseDto;
 import efub.toy2.papers.domain.member.oauth.GoogleUser;
 import efub.toy2.papers.domain.member.repository.MemberRepository;
 import efub.toy2.papers.global.exception.CustomException;
@@ -30,7 +33,6 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MemberService {
     private final MemberRepository memberRepository;
-    private final FolderRepository folderRepository;
     public final FolderService folderService;
     public final S3Service s3Service;
 
@@ -115,6 +117,19 @@ public class MemberService {
         return member.getProfileImgUrl();
     }
 
+    /* 랜덤 회원 목록 조회 : 일단 멤버 리스트 앞에서 3개 자르기*/
+    public List<MemberSearchResponseDto> findRandomMemberList(Member member) {
+        List<Member> randomMemberList;
+        if(member.getRole().equals("ADMIN")) randomMemberList = memberRepository.findAllByMemberIdIsNot(member.getMemberId());
+        else randomMemberList = memberRepository.findAll();
+
+        List<MemberSearchResponseDto> searchResponseDtoList = new ArrayList<>();
+        for(Member randomMember : randomMemberList){
+            searchResponseDtoList.add(new MemberSearchResponseDto(randomMember));
+        }
+        if(searchResponseDtoList.size() > 3) return searchResponseDtoList.subList(0,2);
+        else return searchResponseDtoList;
+    }
 
 
     /* 닉네임 제외한 회원 정보 수정


### PR DESCRIPTION
## 구현 기능
- 본인 제외 회원 목록 리스트(최대 3명)까지 조회하는 api 개발

## 기타
- 원래 랜덤으로 목록을 조회하려 했으나 성능 저하가 심각하다는 문제가 있었음.
- 해당 문제를 고치기 위해서는 DB 설계를 수정하거나, 또는 더 공부 후 다른 방법을 찾아야만 함.
- 현재 배포 및 프로젝트 완성이 급한 상황이므로, 우선 급한대로 앞에서부터 3명 잘라 반환하는 api를 만들어두었고, 이후 리팩토링을 통해 랜덤 조회 기능 구현을 목표로할 것임.