### PR TITLE
fix : 랜덤 회원 조회 시 팔로우 여부도 반환

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/follow/service/FollowService.java
+++ b/src/main/java/efub/toy2/papers/domain/follow/service/FollowService.java
@@ -4,6 +4,8 @@ import efub.toy2.papers.domain.follow.domain.Follow;
 import efub.toy2.papers.domain.follow.dto.FollowResponseDto;
 import efub.toy2.papers.domain.follow.repository.FollowRepository;
 import efub.toy2.papers.domain.member.domain.Member;
+import efub.toy2.papers.domain.member.dto.response.MemberSearchResponseDto;
+import efub.toy2.papers.domain.member.repository.MemberRepository;
 import efub.toy2.papers.domain.member.service.MemberService;
 import efub.toy2.papers.global.exception.CustomException;
 import efub.toy2.papers.global.exception.ErrorCode;
@@ -21,6 +23,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class FollowService {
     private final MemberService memberService;
+    private final MemberRepository memberRepository;
     private final FollowRepository followRepository;
 
     /* 팔로우 생성 */
@@ -94,8 +97,19 @@ public class FollowService {
     }
 
 
-    /* 팔로우하고 있지 않은 멤버 조회 조회 */
-    public List<Follow> findFollowListByNotFollower(Member member){
-        return followRepository.findAllByFollowerIsNot(member);
+
+    /* 랜덤 멤버 목록 조회 : 팔로우 여부도 함께 , 현재는 랜덤 아님 */
+    public List<MemberSearchResponseDto> findRandomMemberList(Member member) {
+        List<Member> randomMemberList;
+        if(member.getRole().equals("ADMIN")) randomMemberList = memberRepository.findAllByMemberIdIsNot(member.getMemberId());
+        else randomMemberList = memberRepository.findAll();
+
+        List<MemberSearchResponseDto> searchResponseDtoList = new ArrayList<>();
+        for(Member randomMember : randomMemberList){
+            Boolean isFollower = isAlreadyFollowed(member,randomMember);
+            searchResponseDtoList.add(new MemberSearchResponseDto(randomMember , isFollower));
+        }
+        if(searchResponseDtoList.size() > 3) return searchResponseDtoList.subList(0,2);
+        else return searchResponseDtoList;
     }
 }

--- a/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
+++ b/src/main/java/efub/toy2/papers/domain/member/controller/MemberController.java
@@ -1,6 +1,7 @@
 package efub.toy2.papers.domain.member.controller;
 
 import efub.toy2.papers.domain.folder.dto.FolderResponseDto;
+import efub.toy2.papers.domain.follow.service.FollowService;
 import efub.toy2.papers.domain.member.domain.Member;
 import efub.toy2.papers.domain.member.dto.ProfileRequestDto;
 import efub.toy2.papers.domain.member.dto.request.LoginRequestDto;
@@ -30,6 +31,7 @@ import java.util.List;
 public class MemberController {
     private final MemberService memberService;
     private final AuthService authService;
+    private final FollowService followService;
 
     /* 로그인 */
     @PostMapping("/auth/login")
@@ -77,24 +79,9 @@ public class MemberController {
     /* 랜덤 회원 목록 리스트 조회 : 우선 팔로우하지 않은 회원 목록 조회하기로... 이후 찾아보고 수정. */
     @GetMapping("/members/random-list")
     public List<MemberSearchResponseDto> getRandomMemberList(@AuthUser Member member){
-        return memberService.findRandomMemberList(member);
-
+        return followService.findRandomMemberList(member);
     }
 
 
 
-
-
-
-    // 그냥 이 api는 삭제시키기
-    /* 프로필 수정 : 닉네임 제외 */
-    /*
-    @PutMapping("/members/profile/update")
-    public MemberInfoDto updateProfile(@AuthUser Member member,
-                                       @RequestPart(value = "introduce" , required = false) String introduce,
-                                       @RequestPart(value="profileImg" , required = false) List<MultipartFile> images) throws IOException{
-        if(!memberService.isAdminMember(member)) throw new CustomException(ErrorCode.NON_LOGIN);
-        return memberService.updateProfile(member,introduce,images);
-    }
-     */
 }

--- a/src/main/java/efub/toy2/papers/domain/member/dto/response/MemberSearchResponseDto.java
+++ b/src/main/java/efub/toy2/papers/domain/member/dto/response/MemberSearchResponseDto.java
@@ -9,12 +9,14 @@ public class MemberSearchResponseDto {
     public String nickname;
     public String introduce;
     public String profileImgURL;
+    public Boolean isFollower;
 
     @Builder
-    public MemberSearchResponseDto(Member member){
+    public MemberSearchResponseDto(Member member , Boolean isFollower){
         this.nickname = member.getNickname();
         this.introduce = member.getIntroduce();
         this.profileImgURL = member.getProfileImgUrl();
+        this.isFollower = isFollower;
 
     }
 }

--- a/src/main/java/efub/toy2/papers/domain/member/service/MemberService.java
+++ b/src/main/java/efub/toy2/papers/domain/member/service/MemberService.java
@@ -117,7 +117,7 @@ public class MemberService {
         return member.getProfileImgUrl();
     }
 
-    /* 랜덤 회원 목록 조회 : 일단 멤버 리스트 앞에서 3개 자르기*/
+    /* 랜덤 회원 목록 조회 : 일단 멤버 리스트 앞에서 3개 자르기
     public List<MemberSearchResponseDto> findRandomMemberList(Member member) {
         List<Member> randomMemberList;
         if(member.getRole().equals("ADMIN")) randomMemberList = memberRepository.findAllByMemberIdIsNot(member.getMemberId());
@@ -130,6 +130,8 @@ public class MemberService {
         if(searchResponseDtoList.size() > 3) return searchResponseDtoList.subList(0,2);
         else return searchResponseDtoList;
     }
+
+     */
 
 
     /* 닉네임 제외한 회원 정보 수정


### PR DESCRIPTION
## 구현 기능
- 응답값으로 현재 팔로우 중인 회원인지 boolean 값으로 반환하도록 추가.


##기타
- 원래 memberService 안에서 해결하려고 함.
- 하지만 그렇게 되면 circular 문제 발생함. -> 의존성 문제인 듯.
- 이게 FK 등 처음 의존 관계 설정이나... 이것저것 수정을 해야 하는 일이 많아서 일단 followService 안에 구현해놓음.
- 이것도 수정할 필요가 있을 것 같다.
- `빈 순환 참조` 에 대해 꼭 공부하기!!