### PR TITLE
[노하은] 스크랩 조회 DTO에 작성시간이 빠져 추가

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/scrap/dto/response/ScrapResponseDto.java
+++ b/src/main/java/efub/toy2/papers/domain/scrap/dto/response/ScrapResponseDto.java
@@ -6,6 +6,7 @@ import efub.toy2.papers.domain.scrapTag.domain.ScrapTag;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -24,6 +25,7 @@ public class ScrapResponseDto {
     private int likeCount;  // 해당 스크랩의 좋아요 개수
     private List<CommentResponseDto> comments;
     private List<String> tags;
+    private LocalDateTime createdAt;
 
     @Builder
     public ScrapResponseDto (Scrap scrap, Boolean liked, int likeCount, List<CommentResponseDto> comments) {
@@ -43,5 +45,6 @@ public class ScrapResponseDto {
         for(ScrapTag tag : scrap.getTags()) {
             tags.add(tag.getTag().getTagName());
         }
+        this.createdAt = scrap.getCreatedAt();
     }
 }


### PR DESCRIPTION
# 구현 기능
- 스크랩 조회 DTO에 작성시간 필드가 누락되어있어 이를 추가함

# 구현 상태
- ScrapResponseDto.java에 createdAt 필드를 추가하고 이를 생성자에 반영.