### PR TITLE
[노하은] 오류 해결

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/efub/toy2/papers/domain/scrap/repository/ScrapRepository.java
@@ -11,7 +11,7 @@ import java.util.List;
 public interface ScrapRepository extends JpaRepository<Scrap , Long>, JpaSpecificationExecutor<Scrap> {
     List<Scrap> findAllByCategory(Category category);
     List<Scrap> findAllByFolderOrderByCreatedAtDesc(Folder folder);
-    List<Scrap> findAllOrderByCreatedAt();
+    List<Scrap> findAllByOrderByCreatedAtDesc();
     List<Scrap> findScrapsByTitleContaining(String query);
     List<Scrap> findScrapsByScrapContentContaining(String query);
 }

--- a/src/main/java/efub/toy2/papers/domain/scrap/service/ScrapService.java
+++ b/src/main/java/efub/toy2/papers/domain/scrap/service/ScrapService.java
@@ -170,7 +170,7 @@ public class ScrapService {
     // 추천 스크랩 리스트 조회 (최신 스크랩 목록)
     public ScrapListResponseDto getRecommendScrap(Long page) {
         // 모든 스크랩 리스트를 시간순으로 받아오기
-        List<Scrap> scraps= scrapRepository.findAllOrderByCreatedAt();
+        List<Scrap> scraps= scrapRepository.findAllByOrderByCreatedAtDesc();
         return paging(scraps, page);
     }
 

--- a/src/main/java/efub/toy2/papers/global/BaseTimeEntity.java
+++ b/src/main/java/efub/toy2/papers/global/BaseTimeEntity.java
@@ -5,6 +5,7 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
@@ -15,8 +16,10 @@ import java.time.LocalDateTime;
 public class BaseTimeEntity {
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
+    @Column
     private LocalDateTime modifiedAt;
 }


### PR DESCRIPTION
# 구현 기능
- 오류 해결

# 구현 상태
- ScrapRepository 내의 메소드 1개의 이름 양식이 잘못되어 오류가 발생함. 수정 완료.
- BaseTimeEntity의 필드들에 @Column 어노테이션이 붙어있지 않아 오류가 발생함. 추가 완료.