### PR TITLE
[노하은] 데이터 관계 수정, S3 저장 path 수정, CASCADE 속성 추가

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/comment/domain/Comment.java
+++ b/src/main/java/efub/toy2/papers/domain/comment/domain/Comment.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -24,10 +26,12 @@ public class Comment extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scrap_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Scrap scrap;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_writer_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member commentWriter;
 
     @Builder

--- a/src/main/java/efub/toy2/papers/domain/follow/domain/Follow.java
+++ b/src/main/java/efub/toy2/papers/domain/follow/domain/Follow.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -21,10 +23,12 @@ public class Follow extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "follower_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member follower;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "following_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member following;
 
     @Builder

--- a/src/main/java/efub/toy2/papers/domain/reply/domain/Reply.java
+++ b/src/main/java/efub/toy2/papers/domain/reply/domain/Reply.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -24,10 +26,12 @@ public class Reply extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "reply_writer_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member replyWriter;
 
     @Builder

--- a/src/main/java/efub/toy2/papers/domain/scrap/domain/Scrap.java
+++ b/src/main/java/efub/toy2/papers/domain/scrap/domain/Scrap.java
@@ -11,6 +11,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -39,14 +41,17 @@ public class Scrap extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scrap_writer_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member scrapWriter;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "folder_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Folder folder;
 
-    @OneToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "category_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Category category;
 
     @OneToMany(mappedBy = "scrap")

--- a/src/main/java/efub/toy2/papers/domain/scrap/service/ScrapService.java
+++ b/src/main/java/efub/toy2/papers/domain/scrap/service/ScrapService.java
@@ -62,7 +62,7 @@ public class ScrapService {
     // 새 스크랩 저장
     public Scrap addScrap(Member member, List<MultipartFile> thumbnail, ScrapWriteRequestDto requestDto) {
         // 새 스크랩 생성 및 저장
-        List<String> imgPaths = s3Service.upload(thumbnail);
+        List<String> imgPaths = s3Service.uploadThumbnail(thumbnail);
         Member writer = memberRepository.findByNickname(member.getNickname()).get();
         Folder folder = folderRepository.findById(requestDto.getFolderId()).get();
         Category category = categoryRepository.findByCategoryName(requestDto.getCategory()).get();
@@ -99,7 +99,7 @@ public class ScrapService {
             throw new CustomException(ErrorCode.INVALID_MEMBER);
 
         // 태그를 제외한 데이터 수정
-        List<String> imgPaths = s3Service.upload(thumbnail);
+        List<String> imgPaths = s3Service.uploadThumbnail(thumbnail);
         Folder folder = folderRepository.findById(requestDto.getFolderId()).get();
         Category category = categoryRepository.findByCategoryName(requestDto.getCategory()).get();
         Scrap savedScrap = scrapRepository.findById(scrapId).get();

--- a/src/main/java/efub/toy2/papers/domain/scrapLike/domain/ScrapLike.java
+++ b/src/main/java/efub/toy2/papers/domain/scrapLike/domain/ScrapLike.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -21,10 +23,12 @@ public class ScrapLike extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scrap_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Scrap scrap;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Member member;
 
     @Builder

--- a/src/main/java/efub/toy2/papers/domain/scrapTag/domain/ScrapTag.java
+++ b/src/main/java/efub/toy2/papers/domain/scrapTag/domain/ScrapTag.java
@@ -7,6 +7,8 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 
 import javax.persistence.*;
 
@@ -21,10 +23,12 @@ public class ScrapTag extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "scrap_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Scrap scrap;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "tag_id")
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Tag tag;
 
     @Builder

--- a/src/main/java/efub/toy2/papers/global/service/S3Service.java
+++ b/src/main/java/efub/toy2/papers/global/service/S3Service.java
@@ -59,7 +59,7 @@ public class S3Service {
     }
 
 
-    /* 이미지 업로드 */
+    /* 이미지 업로드(회원 프로필사진) */
     public List<String> upload(List<MultipartFile> multipartFile) {
         List<String> imgUrlList = new ArrayList<>();
 
@@ -74,6 +74,28 @@ public class S3Service {
                 amazonS3Client.putObject(new PutObjectRequest(bucket+"/member/profile", fileName, inputStream, objectMetadata)
                         .withCannedAcl(CannedAccessControlList.PublicRead));
                 imgUrlList.add(amazonS3Client.getUrl(bucket+"/member/profile", fileName).toString());
+            } catch(IOException e) {
+                throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
+            }
+        }
+        return imgUrlList;
+    }
+
+    /* 이미지 업로드(스크랩 썸네일) */
+    public List<String> uploadThumbnail(List<MultipartFile> multipartFile) {
+        List<String> imgUrlList = new ArrayList<>();
+
+        /* forEach 구문을 통해 multipartFile 로 넘어온 파일들 하나씩 fileNameList 에 추가 */
+        for (MultipartFile file : multipartFile) {
+            String fileName = createFileName(file.getOriginalFilename());
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+
+            try(InputStream inputStream = file.getInputStream()) {
+                amazonS3Client.putObject(new PutObjectRequest(bucket+"/scrap/thumbnail", fileName, inputStream, objectMetadata)
+                        .withCannedAcl(CannedAccessControlList.PublicRead));
+                imgUrlList.add(amazonS3Client.getUrl(bucket+"/scrap/thumbnail", fileName).toString());
             } catch(IOException e) {
                 throw new CustomException(ErrorCode.FILE_UPLOAD_ERROR);
             }


### PR DESCRIPTION
# 구현 기능
- 데이터 관계 수정 (일대일 -> 일대다)
- S3 이미지 저장 path 수정
- CASCADE 속성 추가

# 구현 상태
- 스크랩-폴더, 스크랩-카테고리 의 관계가 일대일로 설정되어있는 것을 발견하여 이를 일대다로 변경함.
- S3 상에서 썸네일이 회원 프로필 사진과 같은 폴더에 저장되고 있음을 발견하여, 경로를 수정함.
- 일대다 속성을 가진 도메인에 CASCADE 속성을 추가하여, 부모 데이터가 삭제될 때 함께 삭제되도록 함.