### PR TITLE
fix : 댓글의 대댓글이 안 달린 경우, 개수가 0으로 반환되도록 수정

### DIFF
--- a/src/main/java/efub/toy2/papers/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/efub/toy2/papers/domain/comment/dto/CommentResponseDto.java
@@ -18,13 +18,14 @@ public class CommentResponseDto {
     public Long replyCount;
 
     @Builder
-    public CommentResponseDto(Comment comment , Boolean commentIsMine , String profileImgUrl , Long replyCount){
+    public CommentResponseDto(Comment comment , Boolean commentIsMine , Long replyCount , String profileImgUrl){
         this.commentId = comment.getCommentId();
         this.scrapId = comment.getScrap().getScrapId();
         this.commentContent = comment.getCommentContent();
         this.writerNickname = comment.getCommentWriter().getNickname();
         this.createdAt = comment.getCreatedAt();
         this.commentIsMine = commentIsMine;
-        this.writerProfileImgUrl = profileImgUrl;
+        this.writerProfileImgUrl = comment.getCommentWriter().getProfileImgUrl();
+        this.replyCount = replyCount;
     }
 }

--- a/src/main/java/efub/toy2/papers/domain/comment/service/CommentService.java
+++ b/src/main/java/efub/toy2/papers/domain/comment/service/CommentService.java
@@ -44,11 +44,9 @@ public class CommentService {
                 .scrap(scrap)
                 .build();
         commentRepository.save(comment);
-
         Boolean isMine = commentIsMine(member,comment);
-        String profileImgUrl = memberService.getProfileImg(member);
         Long replyCount = countReplyByComment(comment);
-        return new CommentResponseDto(comment,isMine, profileImgUrl ,replyCount);
+        return new CommentResponseDto(comment,isMine ,replyCount,comment.getCommentWriter().getProfileImgUrl());
     }
 
     /* 댓글 삭제 */
@@ -66,9 +64,8 @@ public class CommentService {
         List<CommentResponseDto> commentResponseDtoList =new ArrayList<>();
         for(Comment comment : commentList){
             Boolean isMine = commentIsMine(member,comment);
-            String profileImgUrl = memberService.getProfileImg(comment.getCommentWriter());
             Long replyCount = countReplyByComment(comment);
-            commentResponseDtoList.add(new CommentResponseDto(comment , isMine ,profileImgUrl , replyCount));
+            commentResponseDtoList.add(new CommentResponseDto(comment , isMine , replyCount , comment.getCommentWriter().getProfileImgUrl()));
         }
         return commentResponseDtoList;
     }
@@ -96,6 +93,8 @@ public class CommentService {
 
     /* 댓글롤 대댓글 수 조회 */
     public Long countReplyByComment(Comment comment){
-        return replyRepository.countByComment(comment);
+        Long replyCount = replyRepository.countByComment(comment);
+        if(replyCount.equals(null)) return 0L;
+        return replyCount;
     }
 }


### PR DESCRIPTION
## 수정 사항
- 댓글에 달린 대댓글의 개수를 조회할 때, 기존에는 대댓글이 달리지 않은 댓글의 경우 null 이 반환됨. 이를 0이 반환되도록 수정

## 기타
- 현재 댓글 응답 dto 코드를 쳐낼 필요가 있음.
- 이 경우 `ScrapService` 의 코드도 수정 필요